### PR TITLE
Use 4 color pal for mon icons

### DIFF
--- a/engine/menus/naming_screen.asm
+++ b/engine/menus/naming_screen.asm
@@ -115,7 +115,7 @@ DisplayNamingScreen:
 	ld [wAnimCounter], a
 .selectReturnPoint
 	call PrintAlphabet
-	call GBPalNormal
+	call GBPalIcons
 .ABStartReturnPoint
 	ld a, [wNamingScreenSubmitName]
 	and a

--- a/engine/menus/party_menu.asm
+++ b/engine/menus/party_menu.asm
@@ -206,7 +206,7 @@ RedrawPartyMenu_::
 	ld a, 1
 	ldh [hAutoBGTransferEnabled], a
 	call Delay3
-	jp GBPalNormal
+	jp GBPalIcons
 .printItemUseMessage
 	and $0F
 	ld hl, PartyMenuItemUseMessagePointers

--- a/home/palettes.asm
+++ b/home/palettes.asm
@@ -21,22 +21,25 @@ Delay3::
 	jp DelayFrames
 
 GBPalNormal::
-; Reset BGP and OBP0.
-	ld a, %11100100 ; 3210
-	ldh [rBGP], a
+; Reset OBP0 to default
 	ld a, %11010000 ; 3100
+	jr GBPalOBP0Set
+GBPalIcons::
+; Reset OBP0 for icons
+	ld a, %11100100 ; 3210
+GBPalOBP0Set:
+; Set OBP0
 	ldh [rOBP0], a
-	call UpdateGBCPal_BGP
-	call UpdateGBCPal_OBP0
-	call UpdateGBCPal_OBP1
-	ret
-
+	ld a, %11100100 ; 3210
+	jr GBPalUpdate
 GBPalWhiteOut::
 ; White out all palettes.
 	xor a
-	ldh [rBGP], a
 	ldh [rOBP0], a
 	ldh [rOBP1], a
+	; fallthrough
+GBPalUpdate:
+	ldh [rBGP], a
 	call UpdateGBCPal_BGP
 	call UpdateGBCPal_OBP0
 	call UpdateGBCPal_OBP1

--- a/home/palettes.asm
+++ b/home/palettes.asm
@@ -27,18 +27,20 @@ GBPalNormal::
 GBPalIcons::
 ; Reset OBP0 for icons
 	ld a, %11100100 ; 3210
+	; fallthrough
 GBPalOBP0Set:
 ; Set OBP0
 	ldh [rOBP0], a
 	ld a, %11100100 ; 3210
-	jr GBPalUpdate
+	jr GBPalBGPSet
 GBPalWhiteOut::
 ; White out all palettes.
 	xor a
 	ldh [rOBP0], a
 	ldh [rOBP1], a
 	; fallthrough
-GBPalUpdate:
+GBPalBGPSet:
+; Set BGP
 	ldh [rBGP], a
 	call UpdateGBCPal_BGP
 	call UpdateGBCPal_OBP0


### PR DESCRIPTION
Party menu and naming screen normally use 3 color sprites, so switch to using 4 color to get full detail of mon icon sprites on those screens.

The fix involves a small refactor of the GBPal update routines in `home/palettes.asm` to both allow two different settings for OBP0 and to allow those changes to fit into the `HOME` bank.