### PR TITLE
Suggested corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ These videos also provide an overview of the hack and the ideology behind it:
 ## Pret Stuff
 - **All Pret Projects:** [pret.github.io](https://pret.github.io/).
 - [**FAQ**](FAQ.md)
-- [**Documentation**][docs]
 - [**Wiki**][wiki] (includes [tutorials][tutorials])
 - **Discord:** [pret][discord]
 - **IRC:** [libera#pret][irc]
@@ -173,7 +172,6 @@ These videos also provide an overview of the hack and the ideology behind it:
 - [Shinred](https://github.com/jojobear13/shinpokered)
 - [RedStar BlueStar](https://github.com/Rangi42/redstarbluestar)
 - [PureRGB](https://github.com/Vortyne/pureRGB)
-
 
 
 [wiki]: https://github.com/pret/pokeyellow/wiki

--- a/data/pokemon/evos_moves.asm
+++ b/data/pokemon/evos_moves.asm
@@ -1552,9 +1552,9 @@ VaporeonEvosMoves:
 	db 26, BUBBLEBEAM
 	db 30, BITE
 	db 36, AURORA_BEAM
-	db 39, MIST
 	db 39, HAZE
-	db 41, ACID_ARMOR
+	db 41, MIST
+	db 44, ACID_ARMOR
 	db 47, REST
 	db 52, HYDRO_PUMP
 	db 0

--- a/data/pokemon/evos_moves.asm
+++ b/data/pokemon/evos_moves.asm
@@ -1552,9 +1552,9 @@ VaporeonEvosMoves:
 	db 26, BUBBLEBEAM
 	db 30, BITE
 	db 36, AURORA_BEAM
+	db 39, MIST
 	db 39, HAZE
-	db 41, MIST
-	db 44, ACID_ARMOR
+	db 41, ACID_ARMOR
 	db 47, REST
 	db 52, HYDRO_PUMP
 	db 0

--- a/engine/items/item_effects.asm
+++ b/engine/items/item_effects.asm
@@ -486,14 +486,9 @@ ItemUseBall:
 
 	push hl
 
-; If the Pokémon is transformed, the Pokémon is assumed to be a Ditto.
-; This is a bug because a wild Pokémon could have used Transform via
-; Mirror Move even though the only wild Pokémon that knows Transform is Ditto.
 	ld hl, wEnemyBattleStatus3
 	bit TRANSFORMED, [hl]
 	jr z, .notTransformed
-	ld a, DITTO
-	ld [wEnemyMonSpecies2], a
 	jr .skip6
 
 .notTransformed
@@ -2308,7 +2303,6 @@ ItemUsePPRestore:
 	jp .noEffect
 
 ; unsets zero flag if PP was restored, sets zero flag if not
-; however, this is bugged for Max Ethers and Max Elixirs (see below)
 .restorePP
 	xor a ; PLAYER_PARTY_DATA
 	ld [wMonDataLocation], a
@@ -2344,10 +2338,7 @@ ItemUsePPRestore:
 
 .fullyRestorePP
 	ld a, [hl] ; move PP
-; Note that this code has a bug. It doesn't mask out the upper two bits, which
-; are used to count how many PP Ups have been used on the move. So, Max Ethers
-; and Max Elixirs will not be detected as having no effect on a move with full
-; PP if the move has had any PP Ups used on it.
+	and %00111111 ; lower 6 bits store current PP
 	cp b ; does current PP equal max PP?
 	ret z
 	jr .storeNewAmount

--- a/text/CeladonCity.asm
+++ b/text/CeladonCity.asm
@@ -113,9 +113,9 @@ _CeladonCityTrainerTips2Text::
 
 	para "GUARD SPEC."
 	line "protects #MON"
-	cont "against SPECIAL"
-	cont "attacks such as"
-	cont "fire and water!"
+	cont "from status-"
+	cont "reduction moves"
+	cont "during battle."
 
 	para "Get your items at"
 	line "CELADON DEPT."

--- a/text/SafariZoneEast.asm
+++ b/text/SafariZoneEast.asm
@@ -11,6 +11,6 @@ _SafariZoneEastTrainerTipsText::
 	done
 
 _SafariZoneEastSignText::
-	text "CENTER AREA"
+	text "AREA 1"
 	line "NORTH: AREA 2"
 	done


### PR DESCRIPTION
Changed readme links that linked to the Pokémon Crystal dissassembly instead of Yellow.
Corrected Trainer Tips sign in Celadon City that inaccurately described the function of Guard Spec.
Corrected a sign in the east area of the Safari Zone that called it "Center Area" instead of "Area 1".
Fixed PP-restoring items not accounting for PP Ups used.
Corrected HP-draining moves and Dream Eater working on Substitutes when they shouldn't (a bug introduced in the international versions).
Fixed all transformed Pokémon turning into Ditto, as this can cause problems when catching Mew or the Pidgey and Spearow lines if Mirror Move turns into Transform.
Fixed Bide damage not getting cleared properly in link battles if you are the host.
Removed comments in core.asm about screen tearing bug that was already fixed.
Altered Vaporeon's learnset; being programmed to learn both Haze and Mist at the same level means it cannot learn Mist outside the daycare.