### PR TITLE
Fix the forbid printing pokedex vc patch not being present.

### DIFF
--- a/engine/menus/pokedex.asm
+++ b/engine/menus/pokedex.asm
@@ -111,7 +111,13 @@ HandlePokedexSideMenu:
 	dec a
 	jr z, .choseArea
 	dec a
+	vc_patch Forbid_printing_Pokedex
+IF DEF (_YELLOW_VC)
+	jr z, .handleMenuInput
+ELSE
 	jr z, .chosePrint
+ENDC
+	vc_patch_end
 .choseQuit
 	ld b, 1
 .exitSideMenu


### PR DESCRIPTION
Copied from https://github.com/pret/pokeyellow/blob/7f78fed85a8c8b0ba83ff982f35d2db01ba58aad/engine/menus/pokedex.asm#L114