### PR TITLE
Remove Further HM Restrictions in DayCare.

### DIFF
--- a/data/moves/hm_moves.asm
+++ b/data/moves/hm_moves.asm
@@ -2,9 +2,9 @@
 ; - for HMMoves in home/names.asm
 ; - for HMMoveArray in engine/pokemon/bills_pc.asm
 
-	db CUT
-	db FLY
-	db SURF
-	db STRENGTH
-	db FLASH
-	db -1 ; end
+;	db CUT
+;	db FLY
+;	db SURF
+;	db STRENGTH
+;	db FLASH
+;	db -1 ; end

--- a/engine/pokemon/bills_pc.asm
+++ b/engine/pokemon/bills_pc.asm
@@ -390,35 +390,35 @@ BillsPCMenuText:
 BoxNoPCText:
 	db "BOX No.@"
 
-KnowsHMMove::
+;KnowsHMMove::
 ; returns whether mon with party index [wWhichPokemon] knows an HM move
-	ld hl, wPartyMon1Moves
-	ld bc, wPartyMon2 - wPartyMon1
-	jr .next
+;	ld hl, wPartyMon1Moves
+;	ld bc, wPartyMon2 - wPartyMon1
+;	jr .next
 ; unreachable
-	ld hl, wBoxMon1Moves
-	ld bc, wBoxMon2 - wBoxMon1
-.next
-	ld a, [wWhichPokemon]
-	call AddNTimes
-	ld b, NUM_MOVES
-.loop
-	ld a, [hli]
-	push hl
-	push bc
-	ld hl, HMMoveArray
-	ld de, 1
-	call IsInArray
-	pop bc
-	pop hl
-	ret c
-	dec b
-	jr nz, .loop
-	and a
-	ret
+;	ld hl, wBoxMon1Moves
+;	ld bc, wBoxMon2 - wBoxMon1
+;.next
+;	ld a, [wWhichPokemon]
+;	call AddNTimes
+;	ld b, NUM_MOVES
+;.loop
+;	ld a, [hli]
+;	push hl
+;	push bc
+;	ld hl, HMMoveArray
+;	ld de, 1
+;	call IsInArray
+;	pop bc
+;	pop hl
+;	ret c
+;	dec b
+;	jr nz, .loop
+;	and a
+;	ret
 
-HMMoveArray:
-INCLUDE "data/moves/hm_moves.asm"
+;HMMoveArray:
+;INCLUDE "data/moves/hm_moves.asm"
 
 DisplayDepositWithdrawMenu:
 	hlcoord 9, 10

--- a/engine/pokemon/learn_move.asm
+++ b/engine/pokemon/learn_move.asm
@@ -162,9 +162,9 @@ TryingToLearn:
 	ld b, 0
 	add hl, bc
 	ld a, [hl]
-	push af
-	push bc
-	call IsMoveHM
+;	push af
+;	push bc
+;	call IsMoveHM
 	pop bc
 	pop de
 	ld a, d

--- a/home/names.asm
+++ b/home/names.asm
@@ -117,13 +117,13 @@ IsItemHM::
 
 ; sets carry if move is an HM, clears carry if move is not an HM
 ; Input: a = move ID
-IsMoveHM::
-	ld hl, HMMoves
-	ld de, 1
-	jp IsInArray
+;IsMoveHM::
+;	ld hl, HMMoves
+;	ld de, 1
+;	jp IsInArray
 
-HMMoves::
-INCLUDE "data/moves/hm_moves.asm"
+;HMMoves::
+;INCLUDE "data/moves/hm_moves.asm"
 
 GetMoveName::
 	push hl

--- a/scripts/Daycare.asm
+++ b/scripts/Daycare.asm
@@ -36,9 +36,9 @@ DaycareGentlemanText:
 	pop af
 	ld hl, .AllRightThenText
 	jp c, .done
-	callfar KnowsHMMove
-	ld hl, .CantAcceptMonWithHMText
-	jp c, .done
+;	callfar KnowsHMMove
+;	ld hl, .CantAcceptMonWithHMText
+;	jp c, .done
 	xor a
 	ld [wPartyAndBillsPCSavedMenuItem], a
 	ld a, [wWhichPokemon]


### PR DESCRIPTION
Fixed that the Player can't give DayCare person a Pokemon to raise if they know an HM move currently.