### PR TITLE
Level Cap Restructure

### DIFF
--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -4133,49 +4133,11 @@ CheckForDisobedience:
 	ld a, [wPlayerID]
 	cp [hl]
 	jr nz, .monIsTraded
-
-	ld a, [wDifficulty] ; Check if player is on hard mode
-	and a
-	jr z, .NormalMode2
-; what level might disobey?
-	ld a, [wGameStage] ; Check if player has beat the game
-	and a
-	ld a, 101
-	jr nz, .next
-	farcall GetBadgesObtained
-	ld a, [wNumSetBits]
-	cp 8
-	ld a, 65 ; Jolteon/Flareon/Vaporeon's level
-	jr nc, .next
-	cp 7
-	ld a, 55 ; Rhydon's level
-	jr nc, .next
-	cp 6
-	ld a, 53 ; Magmar's level
-	jr nc, .next
-	cp 5
-	ld a, 50 ; Alakazam's level
-	jr nc, .next
-    cp 4
-	ld a, 43 ; Venomoth's level
-	jr nc, .next
-	cp 3
-	ld a, 35 ; Vileplume's level
-	jr nc, .next
-	cp 2
-    ld a, 24 ; Bit below Raichu's level
-	jr nc, .next
-	cp 1
-	ld a, 21 ; Starmie's level
-	jr nc, .next
-	ld a, 12 ; Onix's level
-	jp .next
-.NormalMode2
 	inc hl
 	ld a, [wPlayerID + 1]
 	cp [hl]
-	jp z, .canUseMove ; on normal mode non traded pokemon will always obey
-	; it was traded
+	jp z, .canUseMove
+; it was traded
 .monIsTraded
 	ld hl, wObtainedBadges
 	bit BIT_EARTHBADGE, [hl]

--- a/engine/battle/experience.asm
+++ b/engine/battle/experience.asm
@@ -123,43 +123,15 @@ GainExperience:
 	ld [wd0b5], a
 	call GetMonHeader
 	ld d, MAX_LEVEL
-
-	ld a, [wDifficulty] ; Check if player is on hard mode
+;;; Hard Mode
+    ld a, [wDifficulty] ; Check if player is on hard mode
 	and a
 	jr z, .next1 ; no level caps if not on hard mode
-
-	ld a, [wGameStage] ; Check if player has beat the game
-	and a
-	ld d, 100
-	jr nz, .next1
-	call GetBadgesObtained
-	ld a, [wNumSetBits]
-	cp 8
-	ld d, 65 ; Jolteon/Flareon/Vaporeon's level
-	jr nc, .next1
-	cp 7
-	ld d, 55 ; Rhydon's level
-	jr nc, .next1
-	cp 6
-	ld d, 53 ; Magmar's level
-	jr nc, .next1
-	cp 5
-	ld d, 50 ; Alakazam's level
-	jr nc, .next1
-    cp 4
-	ld d, 43 ; Venomoth's level
-	jr nc, .next1
-	cp 3
-	ld d, 35 ; Vileplume's level
-	jr nc, .next1
-	cp 2
-    ld d, 24 ; Bit below Raichu's level
-	jr nc, .next1
-	cp 1
-	ld d, 21 ; Starmie's level
-	jr nc, .next1
-	ld d, 12 ; Onix's level
+	call GetLevelCap
+	ld a, [wMaxLevel]
+	ld d, a
 .next1
+;;;
 	callfar CalcExperience ; get max exp
 ; compare max exp with current exp
 	ldh a, [hExperience]
@@ -520,14 +492,37 @@ IsCurrentMonBattleMon:
 ; OUTPUT:
 ; a = set bits in wObtainedBadges
 GetBadgesObtained::
-	push hl
-	push bc
 	push de
 	ld hl, wObtainedBadges
 	ld b, $1
 	call CountSetBits
 	pop de
-	pop bc
-	pop hl
-	ld a, [wNumSetBits]
 	ret
+
+; returns the level cap in wMaxLevel
+GetLevelCap::	
+	ld a, [wGameStage] ; Check if player has beat the game
+	and a
+	ld a, 100
+	jr nz, .storeValue
+	call GetBadgesObtained
+	ld a, [wNumSetBits]
+	ld hl, BadgeLevelRestrictions
+	ld b, 0
+	ld c, a
+	add hl, bc
+	ld a, [hl]
+.storeValue
+	ld [wMaxLevel], a
+	ret
+
+BadgeLevelRestrictions:
+    db 12 ; Onix
+    db 21 ; Starmie
+    db 24 ; Raichu
+    db 35 ; Vileplume
+    db 43 ; Venomoth
+    db 50 ; Alakazam
+    db 53 ; Magmar
+    db 55 ; Rhydon
+    db 65 ; Champion's starter

--- a/engine/items/item_effects.asm
+++ b/engine/items/item_effects.asm
@@ -1474,49 +1474,21 @@ ItemUseMedicine:
 	push hl
 	ld bc, wPartyMon1Level - wPartyMon1
 	add hl, bc ; hl now points to level
-	push hl
+;;; Hard Mode
+	push hl ; store mon's level
 	ld b, MAX_LEVEL
-
-	ld a, [wDifficulty] ; Check if player is on hard mode
+	ld a, [wDifficulty]
 	and a
 	jr z, .next1 ; no level caps if not on hard mode
-
-	ld a, [wGameStage] ; Check if player has beat the game
-	and a
-	jr nz, .next1
-	farcall GetBadgesObtained
-	ld a, [wNumSetBits]
-	cp 8
-	ld b, 65 ; Jolteon/Flareon/Vaporeon's level
-	jr nc, .next1
-	cp 7
-	ld b, 55 ; Rhydon's level
-	jr nc, .next1
-	cp 6
-	ld b, 53 ; Magmar's level
-	jr nc, .next1
-	cp 5
-	ld b, 50 ; Alakazam's level
-	jr nc, .next1
-    cp 4
-	ld b, 43 ; Venomoth's level
-	jr nc, .next1
-	cp 3
-	ld b, 35 ; Vileplume's level
-	jr nc, .next1
-	cp 2
-    ld b, 24 ; Bit below Raichu's level
-	jr nc, .next1
-	cp 1
-	ld b, 21 ; Starmie's level
-	jr nc, .next1
-	ld b, 12 ; Onix's level
+	callfar GetLevelCap
+	ld a, [wMaxLevel]
+	ld b, a
 .next1
-
-	pop hl
+	pop hl ; retrieve mon's level
 	ld a, [hl] ; a = level
 	cp b ; MAX_LEVEL on normal mode, level cap on hard mode
-	jr z, .vitaminNoEffect ; can't raise level above 100
+	jr nc, .vitaminNoEffect ; can't raise level above cap ; Carry is better than zero here.
+;;;
 	inc a
 	ld [hl], a ; store incremented level
 	ld [wCurEnemyLVL], a

--- a/ram/wram.asm
+++ b/ram/wram.asm
@@ -381,7 +381,7 @@ wPlayerMonNumber:: db
 wMenuCursorLocation:: dw
 
 ; index in party of currently battling mon
-wMaxDaycareLevel:: db
+wMaxLevel:: db
 
 	ds 1
 

--- a/scripts/Daycare.asm
+++ b/scripts/Daycare.asm
@@ -77,52 +77,22 @@ DaycareGentlemanText:
 	ld [wMonDataLocation], a
 	call LoadMonData
 	callfar CalcLevelFromExperience
-
-	push bc
-	ld a, [wDifficulty] ; Check if player is on hard mode
-	and a
+;;; Hard Mode
 	ld b, MAX_LEVEL
-	jr z, .next1 ; no level caps if not on hard mode
-
-	ld a, [wGameStage] ; Check if player has beat the game
+	ld a, [wDifficulty]
 	and a
-	jr nz, .next1
-	farcall GetBadgesObtained
-	ld a, [wNumSetBits]
-	cp 8
-	ld b, 65 ; Jolteon/Flareon/Vaporeon's level
-	jr nc, .next1
-	cp 7
-	ld b, 55 ; Rhydon's level
-	jr nc, .next1
-	cp 6
-	ld b, 53 ; Magmar's level
-	jr nc, .next1
-	cp 5
-	ld b, 50 ; Alakazam's level
-	jr nc, .next1
-    cp 4
-	ld b, 43 ; Venomoth's level
-	jr nc, .next1
-	cp 3
-	ld b, 35 ; Vileplume's level
-	jr nc, .next1
-	cp 2
-    ld b, 24 ; Bit below Raichu's level
-	jr nc, .next1
-	cp 1
-	ld b, 21 ; Starmie's level
-	jr nc, .next1
-	ld b, 12 ; Onix's level
-.next1
 	ld a, b
-	ld [wMaxDaycareLevel], a
+	ld [wMaxLevel], a
+	jr z, .next1 ; no level cap on normal mode
+	callfar GetLevelCap
+	ld a, [wMaxLevel]
+	ld b, a
+.next1
 	ld a, d
 	cp b
-	pop bc
 	jr c, .skipCalcExp
 
-	ld a, [wMaxDaycareLevel]
+	ld a, [wMaxLevel]
 	ld d, a
 	callfar CalcExperience
 	ld hl, wDayCareMonExp
@@ -132,9 +102,9 @@ DaycareGentlemanText:
 	ld [hli], a
 	ldh a, [hExperience + 2]
 	ld [hl], a
-	ld a, [wMaxDaycareLevel]
+	ld a, [wMaxLevel]
 	ld d, a
-
+;;;
 .skipCalcExp
 	xor a
 	ld [wDayCareNumLevelsGrown], a


### PR DESCRIPTION
Makes editing existing level caps and implementing new ones easier.

Removes functionless code from battle\core that sets a level cap to obedience. The experience clamp ensures that this code will never come into play.

Tested in debug mode. Works fine. 