### PR TITLE
Update Makefile and rgbdscheck to build with newer versions of rgbasm,

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ tools:
 	$(MAKE) -C tools/
 
 
-RGBASMFLAGS = -hL -Q8 -P includes.asm -Weverything -Wnumeric-string=2 -Wtruncation=1
+RGBASMFLAGS = -Q8 -P includes.asm -Weverything -Wtruncation=1
 # Create a sym/map for debug purposes if `make` run with `DEBUG=1`
 ifeq ($(DEBUG),1)
 RGBASMFLAGS += -E

--- a/rgbdscheck.asm
+++ b/rgbdscheck.asm
@@ -1,8 +1,8 @@
-MAJOR EQU 0
-MINOR EQU 6
-PATCH EQU 0
+DEF MAJOR EQU 0
+DEF MINOR EQU 6
+DEF PATCH EQU 0
 
-WRONG_RGBDS EQUS "fail \"pokeyellow requires rgbds v0.6.0 or newer.\""
+DEF WRONG_RGBDS EQUS "fail \"pokeyellow requires rgbds v0.6.0 or newer.\""
 
 IF !DEF(__RGBDS_MAJOR__) || !DEF(__RGBDS_MINOR__) || !DEF(__RGBDS_PATCH__)
 	WRONG_RGBDS


### PR DESCRIPTION
Hello Gentlebeings:

  I run with the latest rgbds from master and there are build failures due to rgbasm changing command line options, and minor macro syntax changes according to the docs. Lifted the makefile changes from pret master. I elected to do a minimally invasive (so i hope change) to rgbdscheck so it will still hopefully build with older tools.

BTW latest pret moved to 0.9.3 or newer

tested on git master and 0.9.3 release